### PR TITLE
Modification de certains icônes pour une meilleur différenciation.

### DIFF
--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -6,7 +6,7 @@ const weatherIconsDay = {
   clear: "day",
   "clear-night": "night",
   cloudy: "cloudy",
-  fog: "cloudy",
+  fog: "cloudy-day-1",
   hail: "rainy-7",
   lightning: "thunder",
   "lightning-rainy": "thunder",
@@ -14,10 +14,10 @@ const weatherIconsDay = {
   pouring: "rainy-6",
   rainy: "rainy-5",
   snowy: "snowy-6",
-  "snowy-rainy": "rainy-7",
+  "snowy-rainy": "snowy-4",
   sunny: "day",
-  windy: "cloudy",
-  "windy-variant": "cloudy-day-3",
+  windy: "cloudy-day-2",
+  "windy-variant": "cloudy-day-2",
   exceptional: "!!",
 };
 
@@ -26,7 +26,9 @@ const weatherIconsNight = {
   clear: "night",
   sunny: "night",
   partlycloudy: "cloudy-night-3",
-  "windy-variant": "cloudy-night-3",
+  "windy-variant": "cloudy-night-2",
+  windy: "cloudy-night-2",
+  fog: "cloudy-night-1",
 };
 
 const windDirections = [

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -6,18 +6,18 @@ const weatherIconsDay = {
   clear: "day",
   "clear-night": "night",
   cloudy: "cloudy",
-  fog: "cloudy-day-1",
+  fog: "fog",
   hail: "rainy-7",
   lightning: "thunder",
-  "lightning-rainy": "thunder",
+  "lightning-rainy": "lightning-rainy",
   partlycloudy: "cloudy-day-3",
   pouring: "rainy-6",
   rainy: "rainy-5",
   snowy: "snowy-6",
-  "snowy-rainy": "snowy-4",
+  "snowy-rainy": "snowy-rainy",
   sunny: "day",
-  windy: "cloudy-day-2",
-  "windy-variant": "cloudy-day-2",
+  windy: "windy",
+  "windy-variant": "windy",
   exceptional: "!!",
 };
 
@@ -26,9 +26,7 @@ const weatherIconsNight = {
   clear: "night",
   sunny: "night",
   partlycloudy: "cloudy-night-3",
-  "windy-variant": "cloudy-night-2",
-  windy: "cloudy-night-2",
-  fog: "cloudy-night-1",
+  "windy-variant": "windy-night",
 };
 
 const windDirections = [


### PR DESCRIPTION
Modification de certains icônes pour une meilleur différenciation, avec les icônes d'origine.
Permet aussi à d'autres jeux d’icônes d'améliorer la visibilités des différents statuts.
A tester voir les changements vous conviennent (j'ai essayé de faire aux mieux avec les icônes présent) -Surtout snowy-4 a la place de rainy-7-. 
A voir si je différencie aussi l'orage, en ajoutant ou doublant un icônes d'origine existant.