### PR TITLE
Suppression des lignes séparant les prévisions

### DIFF
--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -615,10 +615,6 @@ class MeteofranceWeatherCard extends LitElement {
         flex: 1;
         display: block;
         text-align: center;
-        color: var(--primary-text-color);
-        border-right: 0.1em solid #d9d9d9;
-        line-height: 2;
-        box-sizing: border-box;
       }
 
       .dayname {


### PR DESCRIPTION
Supprime les lignes séparant les prévisions sur le bas de la carte suite à une proposition sur discord.