### PR TITLE
feat(config): add new temperatureEntity parameter to bind a custom se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ hide_alertAvalanches: true
 hide_alertVaguesSubmersion: true
 ```
 
+Il est aussi possible d'utiliser un autre capteur pour l'affichage de la température en ajoutant l'élément suivant :
+```yaml
+temperatureEntity: sensor.outdie_temperature
+```
+
 ## Crédits
 
 Projet réalisé par la communauté de HACF et depuis les projets suivants :

--- a/dist/meteofrance-weather-card-editor.js
+++ b/dist/meteofrance-weather-card-editor.js
@@ -30,7 +30,8 @@ const DefaultSensors = new Map([
   ["freezeChanceEntity", "_freeze_chance"],
   ["snowChanceEntity", "_snow_chance"],
   ["uvEntity", "_uv"],
-  ["rainForecastEntity", "_next_rain"]
+  ["rainForecastEntity", "_next_rain"],
+  ["temperatureEntity", ""]
 ])
 
 export class MeteofranceWeatherCardEditor extends LitElement {
@@ -83,6 +84,10 @@ export class MeteofranceWeatherCardEditor extends LitElement {
   // Config value
   get _alertEntity() {
     return this._config.alertEntity || "";
+  }
+
+  get _temperatureEntity() {
+    return this._config.temperatureEntity || "";
   }
 
   get _cloudCoverEntity() {
@@ -163,6 +168,7 @@ export class MeteofranceWeatherCardEditor extends LitElement {
             @value-changed="${this._valueChanged}"
           ></paper-input>
           <!-- Meteo France weather entities -->
+          ${this.renderSensorPicker("Température", this._temperatureEntity, "temperatureEntity")}
           ${this.renderSensorPicker("Risque de pluie", this._rainChanceEntity, "rainChanceEntity")}
           ${this.renderSensorPicker("UV", this._uvEntity, "uvEntity")}
           ${this.renderSensorPicker("Couverture nuageuse", this._cloudCoverEntity, "cloudCoverEntity")}

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -27,7 +27,8 @@ const DefaultSensors = [
   ["freezeChanceEntity", "_freeze_chance"],
   ["snowChanceEntity", "_snow_chance"],
   ["uvEntity", "_uv"],
-  ["rainForecastEntity", "_next_rain"]
+  ["rainForecastEntity", "_next_rain"],
+  ["temperatureEntity", ""]
 ];
 
 const weatherIconsNight = {
@@ -212,6 +213,8 @@ class MeteofranceWeatherCard extends LitElement {
 
     const stateObj = this.hass.states[this._config.entity];
 
+    stateObj.attributes.temperature = this.getTemperature();
+
     if (!stateObj) {
       return html`
         <style>
@@ -264,7 +267,7 @@ class MeteofranceWeatherCard extends LitElement {
         ? html` <div> ${this._config.name} </div>`
         : ""}
           </li>
-          <li>
+          <li @click="${this._handleTemperatureClick}">
               ${this.getUnit("temperature") == "°F"
         ? Math.round(stateObj.attributes.temperature)
         : stateObj.attributes.temperature}
@@ -594,8 +597,22 @@ class MeteofranceWeatherCard extends LitElement {
     }
   }
 
+  getTemperature() {
+    if (this._config.temperatureEntity != null) {
+      return this.hass.states[this._config.temperatureEntity].state;
+    }
+    return this.hass.states[this._config.entity].attributes.temperature;
+  }
+
   _handleClick() {
     fireEvent(this, "hass-more-info", { entityId: this._config.entity });
+  }
+
+  _handleTemperatureClick(e) {
+    if (this._config.temperatureEntity != null) {
+      e.stopPropagation();
+      fireEvent(this, "hass-more-info", { entityId: this._config.temperatureEntity });
+    }
   }
 
   getCardSize() {


### PR DESCRIPTION
…nsor for temperature

This PR proposes to use a custom sensor for current temperature.

Here are modifications :
- Add a new optional `temperatureEntity` card config parameter
- When custom sensor is used, the click action on current temperature opens custom sensor details instead of weather entity details
- The new entity picker was added to lovelace configuration card
- Added a small explanation in `README.md` with the new parameter

This PR addresses in part #78 