### PR TITLE
Fix icons on hourly view

### DIFF
--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -566,12 +566,10 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   getWeatherIcon(condition, sun) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
       ? this._config.icons
-      : "/local/community/lovelace-meteofrance-weather-card2/icons/"
-      }${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+      : "/local/community/lovelace-meteofrance-weather-card/icons/"
+      }${sun && sun.state == "below_horizon"
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -586,8 +586,6 @@ class MeteofranceWeatherCard extends LitElement {
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	console.log(`${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-	  }`)
 	  return `${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
 	  }`;
   }

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -578,7 +578,7 @@ class MeteofranceWeatherCard extends LitElement {
 
     const thistime = datetimehourly ? new Date(datetimehourly) : new Date()
 
-    return ((thistime > nextsetting && thistime < nextrising) || (thistime < nextsetting && thistime < nextrising && nextrising < nextsetting))) 
+    return ((thistime > nextsetting && thistime < nextrising) || (thistime < nextsetting && thistime < nextrising && nextrising < nextsetting)) 
   }
 
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -437,7 +437,7 @@ class MeteofranceWeatherCard extends LitElement {
         })}
             </li>
             <li class="icon" style="background: none, url('${this.getWeatherIcon(
-          daily.condition.toLowerCase(),daily.datetime, isDaily, isNight
+          daily.condition.toLowerCase(), isDaily, isNight
         )}') no-repeat; background-size: contain">
             </li>
             <li class="highTemp">
@@ -559,7 +559,7 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon(condition, datetimehourly, isDaily, isNight) {
+  getWeatherIcon(condition, isDaily, isNight) {
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -31,9 +31,15 @@ const DefaultSensors = [
 ];
 
 const weatherIconsNight = {
-  ...weatherIconsDay,
+					 
   clear: "night",
+  "clear-night": "night",
   sunny: "night",
+  rainy: "rainy-5",
+  snowy: "snowy-6",
+  cloudy: "cloudy",
+  lightning: "thunder",
+  windy: "windy",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
 };
@@ -560,10 +566,12 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   getWeatherIcon(condition, sun) {
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
       ? this._config.icons
-      : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${sun && sun.state == "below_horizon"
+      : "/local/community/lovelace-meteofrance-weather-card2/icons/"
+      }${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -30,15 +30,10 @@ const DefaultSensors = [
   ["rainForecastEntity", "_next_rain"]
 ];
 
-const weatherIconsNight = {				 
+const weatherIconsNight = {
+  ...weatherIconsDay,
   clear: "night",
-  "clear-night": "night",
   sunny: "night",
-  rainy: "rainy-5",
-  snowy: "snowy-6",
-  cloudy: "cloudy",
-  lightning: "thunder",
-  windy: "windy",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
 };

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -422,7 +422,6 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   renderDailyForecast(daily, lang, isDaily) {
-	const isNight = this.isNightTime(daily.datetime)
     return html`
         <li>
           <ul class="flow-column day">
@@ -437,7 +436,7 @@ class MeteofranceWeatherCard extends LitElement {
         })}
             </li>
             <li class="icon" style="background: none, url('${this.getWeatherIcon(
-          daily.condition.toLowerCase(), isDaily, isNight
+          daily.condition.toLowerCase(), isDaily, this.isNightTime(daily.datetime)
         )}') no-repeat; background-size: contain">
             </li>
             <li class="highTemp">
@@ -571,10 +570,13 @@ class MeteofranceWeatherCard extends LitElement {
 
   isNightTime(datetimehourly) {
     const sun = this.hass.states["sun.sun"];
-    if (!sun) { return false}
+    let next_rising;
+    let next_setting;
 
-    let next_rising = new Date(sun.attributes.next_rising);
-    let next_setting = new Date(sun.attributes.next_setting);
+    if (sun) {
+      next_rising = new Date(sun.attributes.next_rising);
+      next_setting = new Date(sun.attributes.next_setting);
+    }
 
     const thistime = datetimehourly ? new Date(datetimehourly) : new Date()
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -133,19 +133,6 @@ function hasConfigOrEntityChanged(element, changedProps) {
   return true;
 }
 
-function isNightTime(datetimehourly) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting ;
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising ;
-	if (datetimehourly &&
-		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
-			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
-		return true;	
-			}
-	return false;
-}
-  
-	
-
 class MeteofranceWeatherCard extends LitElement {
   static get properties() {
     return {
@@ -581,12 +568,14 @@ class MeteofranceWeatherCard extends LitElement {
       }.svg`;
   }
   
-  isNightTime222(datetimehourly) {
+  isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
 	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+			? true
+			: false
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -436,7 +436,7 @@ class MeteofranceWeatherCard extends LitElement {
         })}
             </li>
             <li class="icon" style="background: none, url('${this.getWeatherIcon(
-          daily.condition.toLowerCase(), isDaily, this.isNightTime(daily.datetime)
+          daily.condition.toLowerCase(), this.isNightTime(isDaily, daily.datetime)
         )}') no-repeat; background-size: contain">
             </li>
             <li class="highTemp">
@@ -558,19 +558,19 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon(condition, isDaily, isNight) {
+  getWeatherIcon(condition, isNight) {
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${!isDaily && isNight
+      }${isNight
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;
   }
 
-  isNightTime(datetimehourly) {
+  isNightTime(isDaily, datetimehourly) {
     const sun = this.hass.states["sun.sun"];
-    if (!sun) { return false}
+    if (!sun || isDaily ) { return false}
 
     let nextrising = new Date(sun.attributes.next_rising);
     let nextsetting = new Date(sun.attributes.next_setting);

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -35,7 +35,6 @@ const weatherIconsNight = {
   sunny: "night",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
-  ...weatherIconsDay,
 };
 
 const windDirections = [

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -558,7 +558,7 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon(condition, datetimehourly) {
+  getWeatherIcon2(condition, datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
@@ -570,7 +570,7 @@ class MeteofranceWeatherCard extends LitElement {
       }.svg`;
   }
 
-  getWeatherIcon2(condition, datetimehourly) {
+  getWeatherIcon(condition, datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
@@ -585,7 +585,9 @@ class MeteofranceWeatherCard extends LitElement {
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	  return `${((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+	return `${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+		? true
+		: false
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -31,11 +31,11 @@ const DefaultSensors = [
 ];
 
 const weatherIconsNight = {
-  ...weatherIconsDay,
   clear: "night",
   sunny: "night",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
+  ...weatherIconsDay,
 };
 
 const windDirections = [

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -582,11 +582,10 @@ class MeteofranceWeatherCard extends LitElement {
       }.svg`;
   }
 
-  
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	  return `${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+	  return `${((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -31,11 +31,11 @@ const DefaultSensors = [
 ];
 
 const weatherIconsNight = {
+  ...weatherIconsDay,
   clear: "night",
   sunny: "night",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
-  ...weatherIconsDay,
 };
 
 const windDirections = [

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -580,7 +580,7 @@ class MeteofranceWeatherCard extends LitElement {
 
     const thistime = datetimehourly ? new Date(datetimehourly) : new Date()
 
-    return ((thistime > nextsetting && thistime < nextrising) || (thistime < nextsetting && thistime < nextrising && nextrising < nextsetting)) 
+    return ((datetimehourly > nextsetting && datetimehourly  < nextrising) || (datetimehourly  < nextsetting && datetimehourly  < nextrising && nextrising < nextsetting)) 
   }
 
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -574,8 +574,8 @@ class MeteofranceWeatherCard extends LitElement {
 	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-			? "true"
-			: "false"
+			? false
+			: true
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -133,6 +133,17 @@ function hasConfigOrEntityChanged(element, changedProps) {
   return true;
 }
 
+function isNightTime(datetimehourly) {
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
+	if (datetimehourly)
+		return (
+		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
+			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) 
+  }
+  return false;
+	
+
 class MeteofranceWeatherCard extends LitElement {
   static get properties() {
     return {
@@ -568,13 +579,13 @@ class MeteofranceWeatherCard extends LitElement {
       }.svg`;
   }
   
-  isNightTime(datetimehourly) {
+  isNightTime222(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	  return ${datetimehourly && 
+	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-	  };
+	  }`;
   }
 
   getPhenomenaText(phenomena, sun) {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -562,7 +562,9 @@ class MeteofranceWeatherCard extends LitElement {
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${isNightTime(datetimehourly)
+      }${datetimehourly && 
+		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
+			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -35,6 +35,7 @@ const weatherIconsNight = {
   sunny: "night",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
+  ...weatherIconsDay,
 };
 
 const windDirections = [

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -436,7 +436,7 @@ class MeteofranceWeatherCard extends LitElement {
         })}
             </li>
             <li class="icon" style="background: none, url('${this.getWeatherIcon(
-          daily.condition.toLowerCase(),daily.datetime
+          daily.condition.toLowerCase(),daily.datetime, isDaily
         )}') no-repeat; background-size: contain">
             </li>
             <li class="highTemp">
@@ -558,11 +558,11 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon(condition, datetimehourly) {
+  getWeatherIcon(condition, datetimehourly, isDaily) {
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${this.isNightTime(datetimehourly)
+      }${!isDaily && this.isNightTime(datetimehourly)
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -569,8 +569,15 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   isNightTime(datetimehourly) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
+	const sun = this.hass.states["sun.sun"];
+    let next_rising;
+    let next_setting;
+
+    if (sun) {
+      next_rising = sun.attributes.next_rising;
+      next_setting = sun.attributes.next_setting;
+    }
+	
 	if (datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
 		return true;
 	}

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -558,7 +558,7 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon2(condition, datetimehourly) {
+  getWeatherIcon(condition, datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
@@ -570,7 +570,7 @@ class MeteofranceWeatherCard extends LitElement {
       }.svg`;
   }
 
-  getWeatherIcon(condition, datetimehourly) {
+  getWeatherIcon2(condition, datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -576,6 +576,7 @@ class MeteofranceWeatherCard extends LitElement {
 	}
 	return false;
   }
+  
 
 
   getPhenomenaText(phenomena, sun) {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -136,11 +136,9 @@ function hasConfigOrEntityChanged(element, changedProps) {
 function isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting ;
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising ;
-	console.log("Datetime: " + datetime)
 	if (datetimehourly &&
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
-				console.log("True");
 		return true;	
 			}
 	return false;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -136,12 +136,14 @@ function hasConfigOrEntityChanged(element, changedProps) {
 function isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	if (datetimehourly)
+	if (datetimehourly) {
 		return (
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
-			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) 
-  }
-  return false;
+			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting)));
+		}
+	return false;
+}
+  
 	
 
 class MeteofranceWeatherCard extends LitElement {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -571,10 +571,10 @@ class MeteofranceWeatherCard extends LitElement {
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	  return `${datetimehourly && 
+	  return ${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-	  }`;
+	  };
   }
 
   getPhenomenaText(phenomena, sun) {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -443,7 +443,7 @@ class MeteofranceWeatherCard extends LitElement {
         })}
             </li>
             <li class="icon" style="background: none, url('${this.getWeatherIcon(
-          daily.condition.toLowerCase()
+          daily.condition.toLowerCase(),daily.datetime
         )}') no-repeat; background-size: contain">
             </li>
             <li class="highTemp">
@@ -565,11 +565,13 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon(condition, sun) {
+  getWeatherIcon(condition, datetimehourly) {
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${sun && sun.state == "below_horizon"
+      }${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -574,8 +574,6 @@ class MeteofranceWeatherCard extends LitElement {
 	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-			? true
-			: false
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -136,11 +136,11 @@ function hasConfigOrEntityChanged(element, changedProps) {
 function isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	if (datetimehourly) {
-		return (
+	if (datetimehourly &&
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
-			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting)));
-		}
+			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
+		return true;	
+			}
 	return false;
 }
   

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -569,19 +569,15 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   isNightTime(datetimehourly) {
-	const sun = this.hass.states["sun.sun"];
-    let next_rising;
-    let next_setting;
+    const sun = this.hass.states["sun.sun"];
+    if (!sun) { return false}
 
-    if (sun) {
-      next_rising = sun.attributes.next_rising;
-      next_setting = sun.attributes.next_setting;
-    }
+    let nextrising = new Date(sun.attributes.next_rising);
+    let nextsetting = new Date(sun.attributes.next_setting);
+
+    const thistime = datetimehourly ? new Date(datetimehourly) : new Date()
 	
-	if (datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
-		return true;
-	}
-	return false;
+	return ((thistime > nextsetting && thistime < nextrising) || (thistime < nextsetting && thistime < nextrising && nextrising < nextsetting))
   }
   
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -134,11 +134,13 @@ function hasConfigOrEntityChanged(element, changedProps) {
 }
 
 function isNightTime(datetimehourly) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting ;
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising ;
+	console.log("Datetime: " + datetime)
 	if (datetimehourly &&
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
+				console.log("True");
 		return true;	
 			}
 	return false;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -558,7 +558,7 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon(condition, datetimehourly) {
+  getWeatherIcon2(condition, datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
@@ -569,13 +569,24 @@ class MeteofranceWeatherCard extends LitElement {
         : weatherIconsDay[condition]
       }.svg`;
   }
+
+  getWeatherIcon(condition, datetimehourly) {
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
+    return `${this._config.icons
+      ? this._config.icons
+      : "/local/community/lovelace-meteofrance-weather-card/icons/"
+      }${isNightTime(datetimehourly)
+        ? weatherIconsNight[condition]
+        : weatherIconsDay[condition]
+      }.svg`;
+  }
+
   
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	  return `${datetimehourly && 
-		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
-			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+	  return `${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -574,8 +574,8 @@ class MeteofranceWeatherCard extends LitElement {
 	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-			? true
-			: false
+			? "true"
+			: "false"
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -577,10 +577,10 @@ class MeteofranceWeatherCard extends LitElement {
       next_rising = new Date(sun.attributes.next_rising);
       next_setting = new Date(sun.attributes.next_setting);
     }
-
-    const thistime = datetimehourly ? new Date(datetimehourly) : new Date()
-
-    return ((datetimehourly > nextsetting && datetimehourly  < nextrising) || (datetimehourly  < nextsetting && datetimehourly  < nextrising && nextrising < nextsetting)) 
+	if (datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
+		return true;
+	}
+	return false;
   }
 
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -564,10 +564,17 @@ class MeteofranceWeatherCard extends LitElement {
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+      }${isNightTime(datetimehourly)
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;
+  }
+  
+  isNightTime(datetimehourly) {
+	  return `${datetimehourly && 
+		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
+			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+	  }`;
   }
 
   getPhenomenaText(phenomena, sun) {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -586,6 +586,8 @@ class MeteofranceWeatherCard extends LitElement {
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
+	console.log(`${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+	  }`)
 	  return `${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
 	  }`;
   }

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -30,8 +30,7 @@ const DefaultSensors = [
   ["rainForecastEntity", "_next_rain"]
 ];
 
-const weatherIconsNight = {
-					 
+const weatherIconsNight = {				 
   clear: "night",
   "clear-night": "night",
   sunny: "night",

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -585,10 +585,11 @@ class MeteofranceWeatherCard extends LitElement {
   isNightTime(datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
 	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
-	return `${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-		? true
-		: false
-	  }`;
+	if (datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
+		return true;
+	}
+	return false;
+		
   }
 
   getPhenomenaText(phenomena, sun) {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -559,6 +559,8 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   getWeatherIcon(condition, datetimehourly) {
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -560,13 +560,11 @@ class MeteofranceWeatherCard extends LitElement {
 
   getWeatherIcon(condition, datetimehourly) {
 	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${datetimehourly && 
-		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
-			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
+      }${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -569,14 +569,8 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   isNightTime(datetimehourly) {
-    const sun = this.hass.states["sun.sun"];
-    let next_rising;
-    let next_setting;
-
-    if (sun) {
-      next_rising = new Date(sun.attributes.next_rising);
-      next_setting = new Date(sun.attributes.next_setting);
-    }
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
 	if (datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))) {
 		return true;
 	}

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -559,8 +559,6 @@ class MeteofranceWeatherCard extends LitElement {
   }
 
   getWeatherIcon(condition, datetimehourly) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
@@ -571,6 +569,8 @@ class MeteofranceWeatherCard extends LitElement {
   }
   
   isNightTime(datetimehourly) {
+	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
+	var nextrising = this.hass.states["sun.sun"].attributes.next_rising 
 	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -31,11 +31,10 @@ const DefaultSensors = [
 ];
 
 const weatherIconsNight = {
+  ...weatherIconsDay,	
   clear: "night",
   sunny: "night",
   partlycloudy: "cloudy-night-3",
-  "windy-variant": "cloudy-night-3",
-  ...weatherIconsDay,
 };
 
 const windDirections = [

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -574,8 +574,8 @@ class MeteofranceWeatherCard extends LitElement {
 	  return `${datetimehourly && 
 		((datetimehourly > nextsetting && datetimehourly < nextrising) || 
 			(datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-			? false
-			: true
+			? true
+			: false
 	  }`;
   }
 

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -558,21 +558,7 @@ class MeteofranceWeatherCard extends LitElement {
     return phenomenaList;
   }
 
-  getWeatherIcon2(condition, datetimehourly) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
-    return `${this._config.icons
-      ? this._config.icons
-      : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${datetimehourly && ((datetimehourly > nextsetting && datetimehourly < nextrising) || (datetimehourly < nextsetting && datetimehourly < nextrising && nextrising < nextsetting))
-        ? weatherIconsNight[condition]
-        : weatherIconsDay[condition]
-      }.svg`;
-  }
-
   getWeatherIcon(condition, datetimehourly) {
-	var nextsetting = this.hass.states["sun.sun"].attributes.next_setting
-	var nextrising = this.hass.states["sun.sun"].attributes.next_rising  
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
@@ -589,7 +575,6 @@ class MeteofranceWeatherCard extends LitElement {
 		return true;
 	}
 	return false;
-		
   }
 
   getPhenomenaText(phenomena, sun) {

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -576,7 +576,7 @@ class MeteofranceWeatherCard extends LitElement {
     return `${this._config.icons
       ? this._config.icons
       : "/local/community/lovelace-meteofrance-weather-card/icons/"
-      }${isNightTime(datetimehourly)
+      }${this.isNightTime(datetimehourly)
         ? weatherIconsNight[condition]
         : weatherIconsDay[condition]
       }.svg`;


### PR DESCRIPTION
Shows night-time icons correctly, which is only visible in hourly view
At present the card shows the daily icons for night time as it is based on below_horizon being the actual time, not the time rated to the forecasted figurs
Example after, showing the moon when forecast is after after sunset

![image](https://user-images.githubusercontent.com/44190435/235309397-2202dbf1-c35a-490d-839e-4fd79f602ac8.png)
