### PR TITLE
Add possibility to remove some details on hourly forecast

### DIFF
--- a/dist/meteofrance-weather-card-editor.js
+++ b/dist/meteofrance-weather-card-editor.js
@@ -56,93 +56,98 @@ export class MeteofranceWeatherCardEditor extends LitElement {
   }
 
   get _entity() {
-    return this._config?.entity || "";
+    return this._config.entity || "";
   }
 
   get _name() {
-    return this._config?.name || "";
+    return this._config.name || "";
   }
 
   get _icons() {
-    return this._config?.icons || "";
+    return this._config.icons || "";
   }
 
   get _current() {
-    return this._config?.current !== false;
+    return this._config.current !== false;
   }
 
   get _details() {
-    return this._config?.details !== false;
+    return this._config.details !== false;
   }
 
   get _daily_forecast() {
-    return this._config?.daily_forecast !== false;
+    return this._config.daily_forecast !== false;
   }
 
   get _number_of_daily_forecasts() {
-    return this._config?.number_of_daily_forecasts || 5;
+    return this._config.number_of_daily_forecasts || 5;
   }
 
   get _hourly_forecast() {
-    return this._config?.hourly_forecast !== false;
+    return this._config.hourly_forecast !== false;
   }
 
   get _number_of_hourly_forecasts() {
-    return this._config?.number_of_hourly_forecasts || 5;
+    return this._config.number_of_hourly_forecasts || 5;
   }
+
+  get _hourly_forecast_details() {
+    return this._config.hourly_forecast_details !== false;
+  }
+
 
   // Météo France
   // Switches state
   get _one_hour_forecast() {
-    return this._config?.one_hour_forecast !== false;
+    return this._config.one_hour_forecast !== false;
   }
 
   get _alert_forecast() {
-    return this._config?.alert_forecast !== false;
+    return this._config.alert_forecast !== false;
   }
 
   get _animated_icons() {
-    return this._config?.animated_icons !== false;
+    return this._config.animated_icons !== false;
   }
 
   get _wind_forecast_icons() {
-    return this._config?.wind_forecast_icons !== false;
+    return this._config.wind_forecast_icons !== false;
   }
   
   get _humidity_forecast() {
-    return this._config?.humidity_forecast !== false;
+    return this._config.humidity_forecast !== false;
   }  
 
   get _alertEntity() {
-    return this._config?.alertEntity || "";
+    return this._config.alertEntity || "";
   }
 
   get _cloudCoverEntity() {
-    return this._config?.cloudCoverEntity || "";
+    return this._config.cloudCoverEntity || "";
   }
 
   get _freezeChanceEntity() {
-    return this._config?.freezeChanceEntity || "";
+    return this._config.freezeChanceEntity || "";
   }
 
   get _rainChanceEntity() {
-    return this._config?.rainChanceEntity || "";
+    return this._config.rainChanceEntity || "";
   }
 
   get _rainForecastEntity() {
-    return this._config?.rainForecastEntity || "";
+    return this._config.rainForecastEntity || "";
   }
 
   get _snowChanceEntity() {
-    return this._config?.snowChanceEntity || "";
+    return this._config.snowChanceEntity || "";
   }
 
   get _uvEntity() {
-    return this._config?.uvEntity || "";
+    return this._config.uvEntity || "";
   }
 
   get _detailEntity() {
-    return this._config?.detailEntity || "";
+    return this._config.detailEntity || "";
   }
 
   firstUpdated() {
@@ -182,6 +187,11 @@ export class MeteofranceWeatherCardEditor extends LitElement {
               "Pluie dans l'heure",
               this._one_hour_forecast,
               "one_hour_forecast"
+            )}
+            ${this.renderSwitchOption(
+              "Prévisions par heure - Détails",
+              this._hourly_forecast_details,
+              "hourly_forecast_details"
             )}
             ${this.renderSwitchOption(
               "Prévisions par heure",

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -607,16 +607,6 @@ class MeteofranceWeatherCard extends LitElement {
         <li>
           ${isDaily
             ? new Date(daily.datetime).toLocaleDateString(lang, {
-                weekday: "short",
-              })
-            : new Date(daily.datetime).toLocaleDateString(lang, {
-                weekday: "short",
-                day: "numeric",
-              })}
-        </li>
-        <li>
-          ${isDaily
-            ? new Date(daily.datetime).toLocaleDateString(lang, {
                 day: "numeric",
                 month: "short",
               })
@@ -644,7 +634,8 @@ class MeteofranceWeatherCard extends LitElement {
           : ""}
         ${!this._config.hide_precipitation &&
         daily.precipitation !== undefined &&
-        daily.precipitation !== null
+        daily.precipitation !== null &&
+        this.isSelected(this._config.hourly_forecast_details)
           ? html`
               <li class="precipitation">
                 ${Math.round(daily.precipitation * 10) / 10}
@@ -654,7 +645,8 @@ class MeteofranceWeatherCard extends LitElement {
           : ""}
         ${this.isSelected(this._config.humidity_forecast) &&
         daily.humidity !== undefined &&
-        daily.humidity !== null
+        daily.humidity !== null &&
+        this.isSelected(this._config.hourly_forecast_details)
           ? html`
               <li class="humidity">
                 ${Math.round(daily.humidity)}
@@ -672,7 +664,7 @@ class MeteofranceWeatherCard extends LitElement {
               </li>
             `
           : ""}		  
-        ${daily.wind_speed !== undefined && daily.wind_speed !== null
+        ${daily.wind_speed !== undefined && daily.wind_speed !== null && this.isSelected(this._config.hourly_forecast_details)
           ? html`
               <li class="wind_speed">
                 ${Math.round(daily.wind_speed)} ${this.getUnit("speed")}

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -609,7 +609,7 @@ class MeteofranceWeatherCard extends LitElement {
             ? new Date(daily.datetime).toLocaleDateString(lang, {
                 weekday: "short",
 		day: "numeric",
-                month: "short",
+//                month: "short",
               })
             : new Date(daily.datetime).toLocaleTimeString(lang, {
                 hour: "2-digit",

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -609,7 +609,7 @@ class MeteofranceWeatherCard extends LitElement {
             ? new Date(daily.datetime).toLocaleDateString(lang, {
                 weekday: "short",
               })
-            :}
+            }
         </li>
 	<li>
           ${isDaily

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -607,6 +607,15 @@ class MeteofranceWeatherCard extends LitElement {
         <li>
           ${isDaily
             ? new Date(daily.datetime).toLocaleDateString(lang, {
+                weekday: "short",
+              })
+            : new Date(daily.datetime).toLocaleDateString(lang, {
+
+              })}
+        </li>
+	<li>
+          ${isDaily
+            ? new Date(daily.datetime).toLocaleDateString(lang, {
                 day: "numeric",
                 month: "short",
               })

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -609,9 +609,7 @@ class MeteofranceWeatherCard extends LitElement {
             ? new Date(daily.datetime).toLocaleDateString(lang, {
                 weekday: "short",
               })
-            : new Date(daily.datetime).toLocaleDateString(lang, {
-
-              })}
+            :}
         </li>
 	<li>
           ${isDaily

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -609,7 +609,7 @@ class MeteofranceWeatherCard extends LitElement {
             ? new Date(daily.datetime).toLocaleDateString(lang, {
                 weekday: "short",
               })
-            }
+            : ""}
         </li>
 	<li>
           ${isDaily

--- a/dist/meteofrance-weather-card.js
+++ b/dist/meteofrance-weather-card.js
@@ -604,17 +604,11 @@ class MeteofranceWeatherCard extends LitElement {
   renderDailyForecast(daily, lang, isDaily) {
     return html` <li>
       <ul class="flow-column day">
-        <li>
-          ${isDaily
-            ? new Date(daily.datetime).toLocaleDateString(lang, {
-                weekday: "short",
-              })
-            : ""}
-        </li>
 	<li>
           ${isDaily
             ? new Date(daily.datetime).toLocaleDateString(lang, {
-                day: "numeric",
+                weekday: "short",
+		day: "numeric",
                 month: "short",
               })
             : new Date(daily.datetime).toLocaleTimeString(lang, {


### PR DESCRIPTION
I'm using this super card. But for hourly forcast, I wanted less informations, juste icon's weather, hours and temperature. I made a small modification, with adding a toggle in the editor to add or remove these informations.

See screenshots below :
 
![Screenshot 2025-04-30 13 17 57](https://github.com/user-attachments/assets/ac8a77b0-5f44-499c-b391-2fe6c28da970)
![Screenshot 2025-04-30 13 18 05](https://github.com/user-attachments/assets/023744cf-ad0e-4876-b53d-3f44169be4ea)

Feel free for more information.
Hope that it can help other users.